### PR TITLE
Locked midi-eye to ‘0.3.9’

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source "https://rubygems.org"
 
-gem 'midi-eye'
+gem 'midi-eye', '0.3.9'
 gem 'curses'
 gem 'sinatra'
 gem 'sinatra-contrib'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -50,7 +50,7 @@ DEPENDENCIES
   alsa-rawmidi
   byebug
   curses
-  midi-eye
+  midi-eye (= 0.3.9)
   midi-jruby
   midi-winmm
   sinatra

--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'rubygems/package_task'
 
 HERE = File.dirname(__FILE__)
 PROJECT_NAME = 'patchmaster'
-GEM_VERSION = '1.2.2'
+GEM_VERSION = '1.2.3'
 GEM_DATE = Time.now.strftime('%Y-%m-%d')
 WEB_SERVER = 'jimmenard.com'
 WEB_DIR = "webapps/#{PROJECT_NAME}"


### PR DESCRIPTION
I followed the instructions on patchmaster.org, but was unable to start the program. After running `bundle install patchmaster`, and executing `patchmaster` from shell, I was greeted with

```
/Users/adhd/.rvm/gems/ruby-2.1.1/gems/patchmaster-1.1.2/lib/patchmaster/instrument.rb:121:in `<class:MockInputPort>': undefined method `input_types' for MIDIEye::Listener:Class (NoMethodError)
```

Noticed Issue#2 and discovered that midi-eye was locked at v0.3.9 in Gemfile.lock, but not in Gemfile.  

Had a hunch this may have been cause of the issue. I cloned the jimm:master and successfully ran `bundle exec bin/patchmaster` on my machine, confirming my suspicion.

I next locked the version of midi-eye to 0.3.9 in the Gemfile. 
To confirmed this fix, I deleted Gemfile.lock and re-ran `bundle` plus `bunde exec bin/patchmaster` and successfully started the program.